### PR TITLE
Issue363

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,8 +183,7 @@
     <!-- style="display: inline; visibility: hidden;-->
     <div id="flyover" class="fly"> </div>
     <!--Create Glossary button on screen-->
-    <!--Commented out Glossary button, which is div below. Reference Issue 363 on explanation for removal.-->
-    <!--<div id="indexmenu" onclick="toggleIndex();">Glossary</div>-->
+    <div id="indexmenu" onclick="toggleIndex();">Glossary</div>
 
     <!-- "Undo" icon made by Hadrien on http://www.flaticon.com/authors/hadrien with CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)-->
     <img id="undoButton" src="./imgs/undo.png" onclick="revertChanges();" onmouseover="toggleChangeLandType();" onmouseout="toggleChangeLandType();">


### PR DESCRIPTION
The glossary button was brought back by uncommenting the changed line in index.html. Refer to #363 for more information.